### PR TITLE
Activate real App Store button (#21)

### DIFF
--- a/app/routes/apps/tiny-maintenance/_index.tsx
+++ b/app/routes/apps/tiny-maintenance/_index.tsx
@@ -169,18 +169,22 @@ export default function TinyMaintenanceLanding() {
           </p>
 
           {/* App Store CTA */}
-          {/* TODO: Replace with real App Store URL and re-enable after launch (issue #21) */}
-          {/* TODO(#21): When converting to <a>, add onClick={() => posthog?.capture("app_store_button_click", { app: "tiny_maintenance" })} */}
-          <span
-            aria-label="Coming soon to the App Store"
-            className="inline-flex items-center gap-3 rounded-2xl px-8 py-4 text-base font-medium tracking-tight"
+          <a
+            aria-label="Download Tiny Maintenance on the App Store"
+            className="inline-flex items-center gap-3 rounded-2xl px-8 py-4 text-base font-medium tracking-tight transition-transform hover:scale-105"
+            href="https://apps.apple.com/us/app/tiny-maintenance/id6760630113"
+            onClick={() => {
+              // @ts-ignore
+              if (window.posthog) {
+                // @ts-ignore
+                window.posthog.capture("app_store_button_click", { app: "tiny_maintenance" });
+              }
+            }}
             style={{
               background: "#1A2535",
               boxShadow: "0 4px 16px rgba(26,37,53,0.20)",
               color: "#F0F4F8",
-              cursor: "default",
-              opacity: 0.6,
-              pointerEvents: "none",
+              textDecoration: "none"
             }}
           >
             <svg
@@ -192,8 +196,8 @@ export default function TinyMaintenanceLanding() {
             >
               <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z" />
             </svg>
-            Coming to App Store
-          </span>
+            Download on the App Store
+          </a>
         </section>
 
         {/* Screenshots */}


### PR DESCRIPTION
Activates the real App Store download button now that the app is live.

## Changes
- Replace disabled span with active a tag linking to App Store
- Update top banner: 'Coming soon — currently in App Store Review' → '🎉 Now available on the App Store!'
- Change button text: 'Coming to App Store' → 'Download on the App Store'
- Remove disabled styling (opacity: 0.6, pointerEvents: 'none', cursor: 'default')
- Add posthog click tracking for analytics
- Add hover scale effect for better UX

## App Store URL
https://apps.apple.com/us/app/tiny-maintenance/id6760630113

Closes #21