### PR TITLE
feat(travel): add general travel advising landing page

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -79,6 +79,7 @@ import '../styles/global.css';
 
       <nav class="nav-links" aria-label="Primary">
         <a href="/#what-i-do">What I do</a>
+        <a href="/travel/" aria-current={Astro.url.pathname.startsWith('/travel/') ? 'page' : undefined}>Travel</a>
         <a href="/apps/tiny-maintenance/" aria-current={Astro.url.pathname.startsWith('/apps/') ? 'page' : undefined}>Apps</a>
         <a href="/atticus-list/" aria-current={Astro.url.pathname === '/atticus-list/' ? 'page' : undefined}>Atticus's list</a>
         <a href="/#contact">Contact</a>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -28,30 +28,34 @@ import '../styles/global.css';
   <title>{title} — ItsAydrian</title>
   <meta name="description" content={description}>
 
-  <meta property="og:title" content={title}>
+  <meta property="og:title" content={`${title} — ItsAydrian`}>
   <meta property="og:description" content={description}>
   <meta property="og:type" content="website">
   <meta property="og:url" content={Astro.url}>
   <meta property="og:image" content={new URL(ogImage, Astro.url)}>
   <meta property="og:image:alt" content={ogImageAlt}>
   <meta property="og:site_name" content="ItsAydrian LLC">
+  <meta property="og:locale" content="en_US">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:creator" content="@itsaydrian">
   <meta name="twitter:site" content="@itsaydrian">
-  <meta name="twitter:title" content={title}>
+  <meta name="twitter:title" content={`${title} — ItsAydrian`}>
   <meta name="twitter:description" content={description}>
   <meta name="twitter:image" content={new URL(ogImage, Astro.url)}>
+  <meta name="twitter:image:alt" content={ogImageAlt}>
 
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <link rel="icon" type="image/png" href="/favicon.png" sizes="32x32">
   <link rel="icon" type="image/x-icon" href="/favicon.ico" sizes="any">
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="canonical" href={Astro.url.href}>
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   {preloadImage && <link rel="preload" as="image" href={preloadImage}>}
   <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Inter:wght@400;500;600;700&family=Noto+Sans+JP:wght@300;400;500&display=swap" rel="stylesheet">
 
+  <slot name="head" />
   <script is:inline>
     (function () {
       try {
@@ -142,7 +146,7 @@ import '../styles/global.css';
       </div>
 
       <div class="footer-meta">
-        <span>© 2026 ItsAydrian LLC. All rights reserved.</span>
+        <span>© {new Date().getFullYear()} ItsAydrian LLC. All rights reserved.</span>
         <span class="jp">いつもありがとうございます</span>
       </div>
     </div>

--- a/src/pages/travel/index.astro
+++ b/src/pages/travel/index.astro
@@ -4,24 +4,21 @@ import Layout from '../../layouts/Layout.astro';
 const pageTitle = "Travel Advising — ItsAydrian Travel";
 const pageDescription = "Curated travel planning for trips worth taking. Certified Fora advisor with deep Japan expertise and a network spanning four continents.";
 ---
-<script type="application/ld+json">
-{"@context":"https://schema.org","@type":"TravelAgency","name":"ItsAydrian Travel","url":"https://itsaydrian.com/travel","email":"aydrian.howard@foratravel.com","founder":{"@type":"Person","name":"Aydrian Howard"},"areaServed":"Worldwide","knowsAbout":["Japan travel","Luxury travel","Itinerary planning","Hotel sourcing","Restaurant reservations"],"memberOf":{"@type":"Organization","name":"Fora Travel"},"sameAs":["https://www.foratravel.com/advisor/aydrian-howard"]}
-</script>
-
 <Layout
-  title="Travel"
+  title={pageTitle}
   description={pageDescription}
   ogImage="/assets/aydrian-travel.jpg"
   ogImageAlt="Aydrian traveling — curated trips, planned well."
   overlayHeader={true}
   preloadImage="/assets/aydrian-travel.jpg"
 >
+  <script slot="head" type="application/ld+json" is:raw>{"@context":"https://schema.org","@type":"TravelAgency","name":"ItsAydrian Travel","url":"https://itsaydrian.com/travel","email":"aydrian.howard@foratravel.com","founder":{"@type":"Person","name":"Aydrian Howard"},"areaServed":"Worldwide","knowsAbout":["Japan travel","Luxury travel","Itinerary planning","Hotel sourcing","Restaurant reservations"],"memberOf":{"@type":"Organization","name":"Fora Travel"},"sameAs":["https://www.foratravel.com/advisor/aydrian-howard"]}</script>
   <!-- ============================== HERO ============================== -->
   <section class="hero" aria-labelledby="travel-hero-title">
     <div class="hero-image">
       <picture>
         <source media="(max-width: 800px)" srcset="/assets/aydrian-travel-800.jpg">
-        <img src="/assets/aydrian-travel.jpg" alt="Aydrian on a train platform with luggage, ready to travel." fetchpriority="high">
+        <img src="/assets/aydrian-travel.jpg" alt="Aydrian on a train platform with luggage, ready to travel." width="1200" height="675" fetchpriority="high">
       </picture>
     </div>
 
@@ -34,21 +31,21 @@ const pageDescription = "Curated travel planning for trips worth taking. Certifi
         handled. You show up and enjoy it.
       </p>
       <div class="hero-cta rise" data-delay="3">
-        <a class="btn btn-primary" href="https://www.foratravel.com/advisor/aydrian-howard" target="_blank" rel="noopener noreferrer">
+        <a class="btn btn-primary" href="https://www.foratravel.com/advisor/aydrian-howard" target="_blank" rel="noopener noreferrer" aria-label="Start planning (opens in new tab)">
           Start planning
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M7 17 17 7"/><path d="M7 7h10v10"/></svg>
         </a>
         <a class="btn btn-ghost" href="#inquiry">
-          Tell me where
+          Tell me where you're going
         </a>
       </div>
     </div>
 
-    <a href="#intro" class="hero-scroll" aria-label="Scroll to intro">Read on</a>
+    <a href="#intro" class="hero-scroll" aria-label="Read on">Read on</a>
   </section>
 
   <!-- ============================== INTRO ============================== -->
-  <section id="intro" class="intro">
+  <section id="intro" class="intro" aria-label="Introduction">
     <div class="container">
       <div class="intro-grid">
         <p class="intro-lead rise">
@@ -117,7 +114,7 @@ const pageDescription = "Curated travel planning for trips worth taking. Certifi
           <span class="eyebrow rise">Deep expertise</span>
           <h2 class="h2 rise" data-delay="1">Japan is a <em>specialty.</em></h2>
           <p class="lede rise" data-delay="2">
-            Four years of Japanese study. Yearly trips. JLPT N5 certified and climbing.
+            Four years of Japanese study. Yearly trips. JLPT-tested and working toward fluency.
             This isn't armchair travel — it's lived experience.
           </p>
           <p class="body rise" data-delay="3">
@@ -131,14 +128,14 @@ const pageDescription = "Curated travel planning for trips worth taking. Certifi
           </p>
         </div>
         <div class="split-media rise" data-delay="2">
-          <img src="/assets/aydrian-tokyo-hero-1600.jpg" alt="Aydrian on a neon-lit Tokyo street at night.">
+          <img src="/assets/aydrian-tokyo-hero-1600.jpg" alt="Aydrian on a neon-lit Tokyo street at night." width="800" height="600" loading="lazy">
         </div>
       </div>
     </div>
   </section>
 
   <!-- ============================== CREDIBILITY ============================== -->
-  <section class="section">
+  <section class="section" aria-label="Credentials">
     <div class="container">
       <div class="credibility-strip" style="display: flex; flex-wrap: wrap; gap: var(--space-8); align-items: center; justify-content: center;">
         <div class="credibility-item rise" style="text-align: center;">
@@ -155,50 +152,29 @@ const pageDescription = "Curated travel planning for trips worth taking. Certifi
         </div>
         <div class="credibility-item rise" data-delay="3" style="text-align: center;">
           <p style="font-size: var(--text-3xl); font-weight: 700; color: var(--color-fg); line-height: 1;">1</p>
-          <p style="font-size: var(--text-sm); color: var(--color-muted);">Person handling everything</p>
+          <p style="font-size: var(--text-sm); color: var(--color-muted);">Always direct</p>
         </div>
       </div>
     </div>
   </section>
 
-  <!-- ============================== INQUIRY FORM ============================== -->
+  <!-- ============================== INQUIRY ============================== -->
   <section class="section section-soft" id="inquiry">
-    <div class="container" style="max-width: 64ch;">
-      <header class="section-head rise" style="text-align:center;">
+    <div class="container" style="max-width: 64ch; text-align: center;">
+      <header class="section-head rise">
         <span class="eyebrow">Get started</span>
-        <h2 class="h2">Where do you want to go?</h2>
-        <p class="lede">Drop your email and a few details. I'll be in touch within 24 hours.</p>
+        <h2 class="h2">Get in touch</h2>
+        <p class="lede">Ready to start planning? Send me an email and I'll be in touch within 24 hours.</p>
       </header>
 
-      <form
-        class="inquiry-form rise"
-        action="https://formspree.io/f/YOUR_FORM_ID"
-        method="POST"
-        data-delay="1"
-      >
-        <div class="form-group">
-          <label for="name">Name</label>
-          <input type="text" id="name" name="name" required placeholder="Your name">
-        </div>
-        <div class="form-group">
-          <label for="email">Email</label>
-          <input type="email" id="email" name="email" required placeholder="you@example.com">
-        </div>
-        <div class="form-group">
-          <label for="destination">Destination (or vibe)</label>
-          <input type="text" id="destination" name="destination" required placeholder="Japan, Italy, 'somewhere warm in February'...">
-        </div>
-        <div class="form-group">
-          <label for="details">Tell me more</label>
-          <textarea id="details" name="details" rows="4" placeholder="Trip type, dates, budget range, must-sees, concerns..."></textarea>
-        </div>
-        <button type="submit" class="btn btn-primary btn-lg" style="width: 100%;">
-          Send inquiry
-        </button>
-        <p style="font-size: var(--text-xs); color: var(--color-muted); text-align: center; margin-top: var(--space-4);">
-          Prefer email? <a href="mailto:aydrian.howard@foratravel.com">aydrian.howard@foratravel.com</a>
+      <div class="rise" data-delay="1" style="margin-top: var(--space-8);">
+        <a class="btn btn-primary btn-lg" href="mailto:aydrian.howard@foratravel.com?subject=Travel%20Inquiry">
+          Send me an email
+        </a>
+        <p style="font-size: var(--text-sm); color: var(--color-muted); margin-top: var(--space-4);">
+          Prefer to book directly? <a href="https://www.foratravel.com/advisor/aydrian-howard" target="_blank" rel="noopener noreferrer">Book through Fora</a>
         </p>
-      </form>
+      </div>
     </div>
   </section>
 
@@ -210,7 +186,7 @@ const pageDescription = "Curated travel planning for trips worth taking. Certifi
         No obligation, no pressure. Just a conversation about where you want to go.
       </p>
       <div class="rise" data-delay="2" style="margin-top: var(--space-8);">
-        <a class="btn btn-primary btn-lg" href="https://www.foratravel.com/advisor/aydrian-howard" target="_blank" rel="noopener noreferrer">
+        <a class="btn btn-primary btn-lg" href="https://www.foratravel.com/advisor/aydrian-howard" target="_blank" rel="noopener noreferrer" aria-label="Book through Fora (opens in new tab)">
           Book through Fora
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M7 17 17 7"/><path d="M7 7h10v10"/></svg>
         </a>
@@ -271,50 +247,5 @@ const pageDescription = "Curated travel planning for trips worth taking. Certifi
     object-fit: cover;
   }
 
-  .inquiry-form {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-4);
-    margin-top: var(--space-8);
-  }
 
-  .form-group {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-1);
-  }
-
-  .form-group label {
-    font-size: var(--text-sm);
-    font-weight: 500;
-    color: var(--color-fg);
-  }
-
-  .form-group input,
-  .form-group textarea {
-    padding: var(--space-3);
-    border: 1px solid var(--color-border);
-    border-radius: var(--radius-md);
-    background: var(--color-bg);
-    color: var(--color-fg);
-    font-size: var(--text-base);
-    font-family: inherit;
-    transition: border-color var(--transition-fast);
-  }
-
-  .form-group input:focus,
-  .form-group textarea:focus {
-    outline: none;
-    border-color: var(--color-accent);
-  }
-
-  .form-group input::placeholder,
-  .form-group textarea::placeholder {
-    color: var(--color-muted);
-  }
-
-  .form-group textarea {
-    resize: vertical;
-    min-height: 100px;
-  }
 </style>

--- a/src/pages/travel/index.astro
+++ b/src/pages/travel/index.astro
@@ -1,0 +1,320 @@
+---
+import Layout from '../../layouts/Layout.astro';
+
+const pageTitle = "Travel Advising — ItsAydrian Travel";
+const pageDescription = "Curated travel planning for trips worth taking. Certified Fora advisor with deep Japan expertise and a network spanning four continents.";
+---
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"TravelAgency","name":"ItsAydrian Travel","url":"https://itsaydrian.com/travel","email":"aydrian.howard@foratravel.com","founder":{"@type":"Person","name":"Aydrian Howard"},"areaServed":"Worldwide","knowsAbout":["Japan travel","Luxury travel","Itinerary planning","Hotel sourcing","Restaurant reservations"],"memberOf":{"@type":"Organization","name":"Fora Travel"},"sameAs":["https://www.foratravel.com/advisor/aydrian-howard"]}
+</script>
+
+<Layout
+  title="Travel"
+  description={pageDescription}
+  ogImage="/assets/aydrian-travel.jpg"
+  ogImageAlt="Aydrian traveling — curated trips, planned well."
+  overlayHeader={true}
+  preloadImage="/assets/aydrian-travel.jpg"
+>
+  <!-- ============================== HERO ============================== -->
+  <section class="hero" aria-labelledby="travel-hero-title">
+    <div class="hero-image">
+      <picture>
+        <source media="(max-width: 800px)" srcset="/assets/aydrian-travel-800.jpg">
+        <img src="/assets/aydrian-travel.jpg" alt="Aydrian on a train platform with luggage, ready to travel." fetchpriority="high">
+      </picture>
+    </div>
+
+    <div class="container hero-inner">
+      <h1 id="travel-hero-title" class="hero-title rise" data-delay="1">
+        Travel is better<br>when someone<br><em>has your back.</em>
+      </h1>
+      <p class="hero-tagline rise" data-delay="2">
+        Curated planning for trips worth taking. Hotels, trains, restaurants, logistics —
+        handled. You show up and enjoy it.
+      </p>
+      <div class="hero-cta rise" data-delay="3">
+        <a class="btn btn-primary" href="https://www.foratravel.com/advisor/aydrian-howard" target="_blank" rel="noopener noreferrer">
+          Start planning
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M7 17 17 7"/><path d="M7 7h10v10"/></svg>
+        </a>
+        <a class="btn btn-ghost" href="#inquiry">
+          Tell me where
+        </a>
+      </div>
+    </div>
+
+    <a href="#intro" class="hero-scroll" aria-label="Scroll to intro">Read on</a>
+  </section>
+
+  <!-- ============================== INTRO ============================== -->
+  <section id="intro" class="intro">
+    <div class="container">
+      <div class="intro-grid">
+        <p class="intro-lead rise">
+          I plan trips the way I want my own trips planned — <em>thoroughly, personally, and without the guesswork.</em>
+        </p>
+
+        <div class="intro-body">
+          <p class="rise" data-delay="1">
+            I'm a certified Fora travel advisor with a network across four continents and a particular
+            obsession with Japan. I've walked the backstreets of Kyoto, navigated Tokyo's subway at rush hour,
+            and eaten my way through Osaka's alleyways. That firsthand knowledge goes into every itinerary.
+          </p>
+          <p class="body rise" data-delay="2">
+            But Japan isn't the only place I know well. Whether it's a honeymoon in Italy, a family reunion
+            in the Caribbean, or a solo adventure in Southeast Asia — I handle the research, booking, and
+            logistics so you don't have to.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============================== SERVICES ============================== -->
+  <section class="section" id="services">
+    <div class="container">
+      <header class="section-head rise" style="text-align:center; margin-inline:auto;">
+        <span class="eyebrow">What I handle</span>
+        <h2 class="h2">The details, <em>sorted.</em></h2>
+        <p class="lede">You dream it. I build the itinerary.</p>
+      </header>
+
+      <div class="services-grid">
+        <div class="service-card rise" data-delay="1">
+          <h3>Itinerary planning</h3>
+          <p>Day-by-day schedules with pacing that makes sense. No 7-museum days. No wasted transfers.</p>
+        </div>
+        <div class="service-card rise" data-delay="2">
+          <h3>Hotel sourcing</h3>
+          <p>Properties that match your style and budget — from boutique ryokans to business-friendly chains.</p>
+        </div>
+        <div class="service-card rise" data-delay="3">
+          <h3>Restaurant reservations</h3>
+          <p>Hard-to-book tables, local favorites, and dietary restrictions handled in advance.</p>
+        </div>
+        <div class="service-card rise" data-delay="4">
+          <h3>Transport & logistics</h3>
+          <p>JR Pass strategy, airport transfers, domestic flights, and the connections between them.</p>
+        </div>
+        <div class="service-card rise" data-delay="5">
+          <h3>Activity booking</h3>
+          <p>Museum tickets, guided tours, cooking classes, onsen reservations — locked in before you land.</p>
+        </div>
+        <div class="service-card rise" data-delay="6">
+          <h3>Real-time support</h3>
+          <p>Mid-trip changes happen. I troubleshoot, rebook, and adjust so you stay on track.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============================== JAPAN SPECIALTY ============================== -->
+  <section class="section section-soft" id="japan">
+    <div class="container">
+      <div class="split" style="--split-gap: var(--space-16);">
+        <div class="split-text">
+          <span class="eyebrow rise">Deep expertise</span>
+          <h2 class="h2 rise" data-delay="1">Japan is a <em>specialty.</em></h2>
+          <p class="lede rise" data-delay="2">
+            Four years of Japanese study. Yearly trips. JLPT N5 certified and climbing.
+            This isn't armchair travel — it's lived experience.
+          </p>
+          <p class="body rise" data-delay="3">
+            I know which train to take, which side of the platform, and which convenience store
+            has the best onigiri. I can read the menus, navigate the apps, and explain the customs.
+            If Japan is on your list, you want someone who's been there, done that, and made the mistakes
+            so you don't have to.
+          </p>
+          <p class="body rise" data-delay="4">
+            <strong>Current trip on the books:</strong> Planning a honeymoon in Japan. Want to be next?
+          </p>
+        </div>
+        <div class="split-media rise" data-delay="2">
+          <img src="/assets/aydrian-tokyo-hero-1600.jpg" alt="Aydrian on a neon-lit Tokyo street at night.">
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============================== CREDIBILITY ============================== -->
+  <section class="section">
+    <div class="container">
+      <div class="credibility-strip" style="display: flex; flex-wrap: wrap; gap: var(--space-8); align-items: center; justify-content: center;">
+        <div class="credibility-item rise" style="text-align: center;">
+          <img src="/assets/fora-profile.jpg" alt="Fora Travel profile" style="width: 80px; height: 80px; border-radius: 50%; object-fit: cover; margin: 0 auto var(--space-4);">
+          <p style="font-size: var(--text-sm); color: var(--color-muted);">Certified Fora Advisor</p>
+        </div>
+        <div class="credibility-item rise" data-delay="1" style="text-align: center;">
+          <p style="font-size: var(--text-3xl); font-weight: 700; color: var(--color-fg); line-height: 1;">4+</p>
+          <p style="font-size: var(--text-sm); color: var(--color-muted);">Years studying Japanese</p>
+        </div>
+        <div class="credibility-item rise" data-delay="2" style="text-align: center;">
+          <p style="font-size: var(--text-3xl); font-weight: 700; color: var(--color-fg); line-height: 1;">4</p>
+          <p style="font-size: var(--text-sm); color: var(--color-muted);">Continents in network</p>
+        </div>
+        <div class="credibility-item rise" data-delay="3" style="text-align: center;">
+          <p style="font-size: var(--text-3xl); font-weight: 700; color: var(--color-fg); line-height: 1;">1</p>
+          <p style="font-size: var(--text-sm); color: var(--color-muted);">Person handling everything</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============================== INQUIRY FORM ============================== -->
+  <section class="section section-soft" id="inquiry">
+    <div class="container" style="max-width: 64ch;">
+      <header class="section-head rise" style="text-align:center;">
+        <span class="eyebrow">Get started</span>
+        <h2 class="h2">Where do you want to go?</h2>
+        <p class="lede">Drop your email and a few details. I'll be in touch within 24 hours.</p>
+      </header>
+
+      <form
+        class="inquiry-form rise"
+        action="https://formspree.io/f/YOUR_FORM_ID"
+        method="POST"
+        data-delay="1"
+      >
+        <div class="form-group">
+          <label for="name">Name</label>
+          <input type="text" id="name" name="name" required placeholder="Your name">
+        </div>
+        <div class="form-group">
+          <label for="email">Email</label>
+          <input type="email" id="email" name="email" required placeholder="you@example.com">
+        </div>
+        <div class="form-group">
+          <label for="destination">Destination (or vibe)</label>
+          <input type="text" id="destination" name="destination" required placeholder="Japan, Italy, 'somewhere warm in February'...">
+        </div>
+        <div class="form-group">
+          <label for="details">Tell me more</label>
+          <textarea id="details" name="details" rows="4" placeholder="Trip type, dates, budget range, must-sees, concerns..."></textarea>
+        </div>
+        <button type="submit" class="btn btn-primary btn-lg" style="width: 100%;">
+          Send inquiry
+        </button>
+        <p style="font-size: var(--text-xs); color: var(--color-muted); text-align: center; margin-top: var(--space-4);">
+          Prefer email? <a href="mailto:aydrian.howard@foratravel.com">aydrian.howard@foratravel.com</a>
+        </p>
+      </form>
+    </div>
+  </section>
+
+  <!-- ============================== CTA ============================== -->
+  <section class="section" style="text-align: center;">
+    <div class="container">
+      <h2 class="h2 rise">Ready when you are.</h2>
+      <p class="lede rise" data-delay="1">
+        No obligation, no pressure. Just a conversation about where you want to go.
+      </p>
+      <div class="rise" data-delay="2" style="margin-top: var(--space-8);">
+        <a class="btn btn-primary btn-lg" href="https://www.foratravel.com/advisor/aydrian-howard" target="_blank" rel="noopener noreferrer">
+          Book through Fora
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M7 17 17 7"/><path d="M7 7h10v10"/></svg>
+        </a>
+      </div>
+    </div>
+  </section>
+</Layout>
+
+<style>
+  .services-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: var(--space-6);
+    margin-top: var(--space-12);
+  }
+
+  .service-card {
+    padding: var(--space-6);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    background: var(--color-bg);
+    transition: box-shadow var(--transition-fast);
+  }
+
+  .service-card:hover {
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.06);
+  }
+
+  .service-card h3 {
+    font-size: var(--text-lg);
+    font-weight: 600;
+    margin-bottom: var(--space-2);
+    color: var(--color-fg);
+  }
+
+  .service-card p {
+    font-size: var(--text-sm);
+    color: var(--color-muted);
+    line-height: 1.6;
+  }
+
+  .split {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--split-gap, var(--space-12));
+    align-items: center;
+  }
+
+  @media (max-width: 800px) {
+    .split {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  .split-media img {
+    width: 100%;
+    border-radius: var(--radius-lg);
+    object-fit: cover;
+  }
+
+  .inquiry-form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+    margin-top: var(--space-8);
+  }
+
+  .form-group {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+  }
+
+  .form-group label {
+    font-size: var(--text-sm);
+    font-weight: 500;
+    color: var(--color-fg);
+  }
+
+  .form-group input,
+  .form-group textarea {
+    padding: var(--space-3);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-bg);
+    color: var(--color-fg);
+    font-size: var(--text-base);
+    font-family: inherit;
+    transition: border-color var(--transition-fast);
+  }
+
+  .form-group input:focus,
+  .form-group textarea:focus {
+    outline: none;
+    border-color: var(--color-accent);
+  }
+
+  .form-group input::placeholder,
+  .form-group textarea::placeholder {
+    color: var(--color-muted);
+  }
+
+  .form-group textarea {
+    resize: vertical;
+    min-height: 100px;
+  }
+</style>


### PR DESCRIPTION
## What\n
- Adds a general travel advising landing page at \n- Positions Aydrian as a curated travel advisor (not Japan-only)\n- Highlights Japan as a deep specialty while keeping it open to other destinations\n- Lists 6 service categories: itinerary, hotels, restaurants, transport, activities, support\n- Adds an inquiry form (Formspree placeholder — needs a real form ID)\n- Updates nav to include a Travel link\n- Adds JSON-LD structured data for TravelAgency schema\n
## Preview\n
- [ ] Open PR to trigger preview deploy\n
## Notes\n
- Formspree form ID is  — needs to be replaced with a real one\n- Alternative: swap for Basin, Getform, or a simple mailto: fallback\n