### PR TITLE
feat: create /apps/ index page (#29)

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -7,6 +7,12 @@
     <priority>1.0</priority>
   </url>
   <url>
+    <loc>https://itsaydrian.com/apps/</loc>
+    <lastmod>2026-05-31</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://itsaydrian.com/apps/tiny-maintenance</loc>
     <lastmod>2026-05-30</lastmod>
     <changefreq>monthly</changefreq>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -94,7 +94,7 @@ import '../styles/global.css';
       <nav class="nav-links" aria-label="Primary">
         <a href="/#what-i-do">What I do</a>
         <a href="/travel/" aria-current={Astro.url.pathname === '/travel/' ? 'page' : undefined}>Travel</a>
-        <a href="/apps/tiny-maintenance/" aria-current={Astro.url.pathname.startsWith('/apps/') ? 'page' : undefined}>Apps</a>
+        <a href="/apps/" aria-current={Astro.url.pathname.startsWith('/apps/') ? 'page' : undefined}>Apps</a>
         <a href="/atticus-list/" aria-current={Astro.url.pathname === '/atticus-list/' ? 'page' : undefined}>Atticus's list</a>
         <a href="/#contact">Contact</a>
       </nav>
@@ -141,6 +141,7 @@ import '../styles/global.css';
             <li><a href="/travel/">Travel advising</a></li>
             <li><a href="https://www.rover.com/sit/aydrih08941" target="_blank" rel="noopener noreferrer">Pet care · Rover</a></li>
             <li><a href="/atticus-list/">Atticus's favorite things</a></li>
+            <li><a href="/apps/">Apps</a></li>
             <li><a href="/apps/tiny-maintenance/">Tiny Maintenance for iOS</a></li>
           </ul>
         </div>

--- a/src/pages/apps/index.astro
+++ b/src/pages/apps/index.astro
@@ -1,0 +1,58 @@
+---
+import Layout from '../../layouts/Layout.astro';
+---
+
+<Layout
+  title="Apps"
+  description="Software I wanted to exist. A small collection of apps built with care."
+  ogImage="/images/apps/tiny-maintenance/og.png"
+  ogImageAlt="Apps by ItsAydrian"
+  ogImageWidth={1200}
+  ogImageHeight={630}
+  ogImageType="image/png"
+>
+  <!-- HERO -->
+  <section class="section">
+    <div class="container">
+      <h1 class="display rise">Software I <em>wanted</em> to exist.</h1>
+      <p class="lede rise">Built with care, designed for real life.</p>
+    </div>
+  </section>
+
+  <!-- APPS GRID -->
+  <section class="section section-soft">
+    <div class="container">
+      <div class="apps-grid">
+        <article class="app-card rise">
+          <img class="app-icon" src="/images/apps/tiny-maintenance/icon.png" alt="" aria-hidden="true">
+          <div class="app-card-body">
+            <h3>Tiny <em>Maintenance.</em></h3>
+            <p class="body">Track recurring upkeep for your home, car, garden, and pets. Reminders, templates, and a one-tap done — offline, no account required.</p>
+          </div>
+          <div class="app-card-cta">
+            <a class="btn btn-primary" href="https://apps.apple.com/us/app/tiny-maintenance/id6760630113" target="_blank" rel="noopener noreferrer">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"/></svg>
+              Download on the App Store
+            </a>
+            <a class="btn-link" href="/apps/tiny-maintenance/">Learn more</a>
+          </div>
+        </article>
+
+        <aside class="coming-soon rise" data-delay="1">
+          <span class="eyebrow">Coming soon</span>
+          <h3>Two more in the workshop.</h3>
+          <p>Something for travel planning. Something for pet people. Early prototypes, no screenshots yet.</p>
+        </aside>
+      </div>
+    </div>
+  </section>
+
+  <!-- EARLY ACCESS CTA -->
+  <section class="section">
+    <div class="container">
+      <h2 class="h2 rise">Want <em>early access?</em></h2>
+      <p class="lede rise" data-delay="1">Be the first to try new apps. No spam, just a heads-up when something's ready.</p>
+      <a class="btn btn-primary rise" data-delay="2" href="mailto:howdy@itsaydrian.com?subject=Early%20access%20request">Email me</a>
+    </div>
+  </section>
+</Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -205,7 +205,7 @@ const pageDescription = "A small studio for the things I'm into — curated trav
               <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"/></svg>
               Download
             </a>
-            <a class="btn-link" href="/apps/tiny-maintenance/">
+            <a class="btn-link" href="/apps/">
               See features
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
             </a>


### PR DESCRIPTION
Closes #29

## What's new
- ✨ **/apps/ index page** — hero with "Software I wanted to exist" positioning, Tiny Maintenance card with App Store + detail page links, coming soon teaser, and early access CTA
- 🔗 **Nav updated** — Apps link now points to /apps/ instead of /apps/tiny-maintenance/
- 🔗 **Footer updated** — Added Apps link above Tiny Maintenance
- 🔗 **Homepage CTA updated** — "See features" now goes to /apps/
- 🗺️ **Sitemap updated** — Added /apps/ entry

## Acceptance criteria
- [x] Page accessible at /apps/
- [x] Nav link updated
- [x] Tiny Maintenance card links to App Store + existing detail page
- [x] Mobile responsive (uses existing responsive styles)
- [x] Dark mode works (uses existing CSS variables)
- [x] Added to sitemap
- [x] Build passes
