### PR TITLE
feat: add subscriber form integration

### DIFF
--- a/src/components/SubscriberForm.astro
+++ b/src/components/SubscriberForm.astro
@@ -117,7 +117,7 @@ const apiUrl = 'https://itsaydrian-subscriber.aydrian.workers.dev/subscribe';
         });
 
         if (res.status === 201) {
-          showStatus('success', "You're subscribed! Check your email for confirmation.");
+          showStatus('success', "Almost there! Check your email to confirm your subscription.");
           form.reset();
         } else if (res.status === 429) {
           showStatus('error', 'Too many attempts. Please try again later.');
@@ -201,20 +201,6 @@ const apiUrl = 'https://itsaydrian-subscriber.aydrian.workers.dev/subscribe';
   .subscriber-input::placeholder {
     color: var(--ink-faint);
     opacity: 0.6;
-  }
-
-  .subscriber-label {
-    font-size: var(--fs-12);
-    font-weight: 600;
-    color: var(--ink-faint);
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-  }
-
-  .subscriber-optional {
-    font-weight: 400;
-    color: var(--ink-faint);
-    opacity: 0.7;
   }
 
   .subscriber-status {

--- a/src/components/SubscriberForm.astro
+++ b/src/components/SubscriberForm.astro
@@ -10,7 +10,7 @@ const formId = `subscriber-form-${uid}`;
 const nameId = `subscriber-name-${uid}`;
 const emailId = `subscriber-email-${uid}`;
 const hpId = `subscriber-hp-${uid}`;
-const apiUrl = 'https://itsaydrian-subscriber.aydrian.workers.dev/subscribe';
+const apiUrl = '/api/subscribe';
 ---
 
 <form class="subscriber-form" id={formId} novalidate>

--- a/src/components/SubscriberForm.astro
+++ b/src/components/SubscriberForm.astro
@@ -1,0 +1,259 @@
+---
+export interface Props {
+  tag?: string;
+}
+
+const { tag } = Astro.props;
+
+const uid = Math.random().toString(36).slice(2, 8);
+const formId = `subscriber-form-${uid}`;
+const nameId = `subscriber-name-${uid}`;
+const emailId = `subscriber-email-${uid}`;
+const hpId = `subscriber-hp-${uid}`;
+const apiUrl = 'https://itsaydrian-subscriber.aydrian.workers.dev/subscribe';
+---
+
+<form class="subscriber-form" id={formId} novalidate>
+  <div class="subscriber-fields">
+    <div class="subscriber-field">
+      <label for={nameId} class="subscriber-label">Name <span class="subscriber-optional">(optional)</span></label>
+      <input
+        type="text"
+        id={nameId}
+        name="name"
+        autocomplete="name"
+        placeholder="Your name"
+        class="subscriber-input"
+      />
+    </div>
+    <div class="subscriber-field">
+      <label for={emailId} class="subscriber-label">Email</label>
+      <input
+        type="email"
+        id={emailId}
+        name="email"
+        required
+        autocomplete="email"
+        placeholder="you@example.com"
+        class="subscriber-input"
+      />
+    </div>
+  </div>
+
+  <!-- Honeypot -->
+  <div class="subscriber-hp" aria-hidden="true">
+    <label for={hpId}>Website</label>
+    <input type="text" id={hpId} name="website" tabindex="-1" autocomplete="off" aria-hidden="true" />
+  </div>
+
+  <button type="submit" class="btn btn-primary subscriber-submit">
+    <span class="subscriber-submit-text">Subscribe</span>
+    <span class="subscriber-submit-loading" hidden>Sending…</span>
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
+  </button>
+
+  <div class="subscriber-status" role="status" aria-live="polite" hidden></div>
+</form>
+
+<script define:vars={{ formId, apiUrl, tag }}>
+  (function() {
+    const form = document.getElementById(formId);
+    if (!form) return;
+    const status = form.querySelector('.subscriber-status');
+    const submitBtn = form.querySelector('.subscriber-submit');
+    const submitText = form.querySelector('.subscriber-submit-text');
+    const submitLoading = form.querySelector('.subscriber-submit-loading');
+
+    function showStatus(type, message) {
+      if (!status) return;
+      status.hidden = false;
+      status.setAttribute('data-type', type);
+      status.textContent = message;
+    }
+
+    function clearStatus() {
+      if (!status) return;
+      status.hidden = true;
+      status.removeAttribute('data-type');
+      status.textContent = '';
+    }
+
+    function setLoading(loading) {
+      submitBtn.disabled = loading;
+      submitText.hidden = loading;
+      submitLoading.hidden = !loading;
+    }
+
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      clearStatus();
+
+      const honeypot = form.querySelector('input[name="website"]');
+      if (honeypot && honeypot.value) {
+        showStatus('success', "You're subscribed!");
+        form.reset();
+        return;
+      }
+
+      const formData = new FormData(form);
+      const email = formData.get('email')?.toString().trim();
+      const name = formData.get('name')?.toString().trim();
+
+      if (!email) {
+        showStatus('error', 'Please enter your email address.');
+        return;
+      }
+
+      setLoading(true);
+
+      try {
+        const payload = { email, name: name || undefined };
+        if (tag) payload.tag = tag;
+
+        const res = await fetch(apiUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+
+        if (res.status === 201) {
+          showStatus('success', "You're subscribed! Check your email for confirmation.");
+          form.reset();
+        } else if (res.status === 429) {
+          showStatus('error', 'Too many attempts. Please try again later.');
+        } else if (res.status === 400) {
+          const data = await res.json().catch(() => ({}));
+          showStatus('error', data.message || 'Invalid email address.');
+        } else {
+          showStatus('error', 'Something went wrong. Please try again.');
+        }
+      } catch (err) {
+        showStatus('error', 'Something went wrong. Please try again.');
+      } finally {
+        setLoading(false);
+      }
+    });
+  })();
+</script>
+
+<style>
+  .subscriber-form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+    max-width: 560px;
+  }
+
+  .subscriber-fields {
+    display: flex;
+    gap: var(--space-4);
+    align-items: flex-end;
+  }
+
+  @media (max-width: 560px) {
+    .subscriber-fields {
+      flex-direction: column;
+      align-items: stretch;
+    }
+  }
+
+  .subscriber-field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    flex: 1;
+  }
+
+  .subscriber-label {
+    font-size: var(--fs-12);
+    font-weight: 600;
+    color: var(--ink-faint);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .subscriber-optional {
+    font-weight: 400;
+    color: var(--ink-faint);
+    opacity: 0.7;
+  }
+
+  .subscriber-input {
+    width: 100%;
+    padding: var(--space-3) var(--space-4);
+    border: 1px solid var(--rule);
+    border-radius: var(--r-md);
+    background: var(--bg);
+    color: var(--ink);
+    font-family: inherit;
+    font-size: var(--fs-14);
+    line-height: 1.5;
+    outline: none;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+    box-sizing: border-box;
+  }
+
+  .subscriber-input:focus {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 2px color-mix(in oklab, var(--accent) 20%, transparent);
+  }
+
+  .subscriber-input::placeholder {
+    color: var(--ink-faint);
+    opacity: 0.6;
+  }
+
+  .subscriber-label {
+    font-size: var(--fs-12);
+    font-weight: 600;
+    color: var(--ink-faint);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .subscriber-optional {
+    font-weight: 400;
+    color: var(--ink-faint);
+    opacity: 0.7;
+  }
+
+  .subscriber-status {
+    padding: var(--space-3) var(--space-4);
+    border-radius: var(--r-md);
+    font-size: var(--fs-14);
+    font-weight: 500;
+    line-height: 1.5;
+  }
+
+  .subscriber-status[data-type="success"] {
+    background: color-mix(in oklab, var(--hydro) 12%, transparent);
+    color: var(--hydro);
+    border: 1px solid color-mix(in oklab, var(--hydro) 28%, transparent);
+  }
+
+  .subscriber-status[data-type="error"] {
+    background: color-mix(in oklab, var(--accent-hot) 10%, transparent);
+    color: var(--accent-hot);
+    border: 1px solid color-mix(in oklab, var(--accent-hot) 25%, transparent);
+  }
+
+  .subscriber-hp {
+    position: absolute;
+    left: -9999px;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+  }
+
+  .subscriber-submit-loading {
+    display: inline;
+  }
+
+  .subscriber-submit-loading[hidden] {
+    display: none;
+  }
+
+  .subscriber-submit-text[hidden] {
+    display: none;
+  }
+</style>

--- a/src/pages/api/subscribe.ts
+++ b/src/pages/api/subscribe.ts
@@ -1,0 +1,65 @@
+import type { APIRoute } from 'astro';
+
+export const prerender = false;
+
+const WORKER_URL = 'https://itsaydrian-subscriber.aydrian.workers.dev/subscribe';
+
+export const POST: APIRoute = async ({ request }) => {
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return json({ success: false, error: 'Invalid request.' }, 400);
+  }
+
+  const { email, name, tag, website } = body;
+
+  // Honeypot — bots fill hidden fields; silently succeed so they think it worked
+  if (website) {
+    return json({ success: true, message: 'Check your email to confirm your subscription.' }, 201);
+  }
+
+  if (!email || typeof email !== 'string') {
+    return json({ success: false, error: 'Please enter your email address.' }, 400);
+  }
+
+  if (!email.includes('@') || !email.includes('.')) {
+    return json({ success: false, error: 'Please enter a valid email address.' }, 400);
+  }
+
+  try {
+    const res = await fetch(WORKER_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: email.trim(),
+        ...(name ? { name: (name as string).trim() } : {}),
+        ...(tag ? { tag } : {}),
+      }),
+    });
+
+    if (res.status === 201) {
+      return json({ success: true, message: 'Check your email to confirm your subscription.' }, 201);
+    }
+
+    if (res.status === 429) {
+      return json({ success: false, error: 'Too many attempts. Please try again later.' }, 429);
+    }
+
+    if (res.status === 400) {
+      const data = await res.json().catch(() => ({})) as Record<string, unknown>;
+      return json({ success: false, error: (data.message as string) || 'Invalid email address.' }, 400);
+    }
+
+    return json({ success: false, error: 'Something went wrong. Please try again.' }, 500);
+  } catch {
+    return json({ success: false, error: 'Something went wrong. Please try again.' }, 500);
+  }
+};
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from '../layouts/Layout.astro';
+import SubscriberForm from '../components/SubscriberForm.astro';
 
 const pageTitle = "Aydrian Howard — ItsAydrian LLC";
 const pageDescription = "A small studio for the things I'm into — curated travel (with a Japan habit), pet care in NYC, and software I want to exist. Run by Aydrian Howard.";
@@ -226,6 +227,20 @@ const pageDescription = "A small studio for the things I'm into — curated trav
     </div>
   </section>
 
+  <!-- ============================== SUBSCRIBE ============================== -->
+  <section class="section section-soft subscriber-section">
+    <div class="container subscriber-grid">
+      <div>
+        <span class="eyebrow rise">Stay in the loop</span>
+        <h2 class="h2 rise" data-delay="1">Get updates when there's something worth sharing.</h2>
+        <p class="lede rise" data-delay="2">Travel tips, app releases, Japan notes, and Atticus photos. No spam. Unsubscribe anytime.</p>
+      </div>
+      <div class="rise" data-delay="3">
+        <SubscriberForm />
+      </div>
+    </div>
+  </section>
+
   <!-- ============================== CONTACT ============================== -->
   <section id="contact" class="contact-band">
     <div class="container">
@@ -241,3 +256,19 @@ const pageDescription = "A small studio for the things I'm into — curated trav
     </div>
   </section>
 </Layout>
+
+<style>
+  .subscriber-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--space-12);
+    align-items: center;
+  }
+
+  @media (max-width: 800px) {
+    .subscriber-grid {
+      grid-template-columns: 1fr;
+      gap: var(--space-8);
+    }
+  }
+</style>

--- a/src/pages/travel/index.astro
+++ b/src/pages/travel/index.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from '../../layouts/Layout.astro';
 import TravelChatWidget from '../../components/TravelChatWidget.astro';
+import SubscriberForm from '../../components/SubscriberForm.astro';
 
 const pageTitle = "Travel Advising — ItsAydrian Travel";
 const pageDescription = "Curated travel planning for trips worth taking. Certified Fora advisor with deep Japan expertise and a network spanning four continents.";
@@ -175,6 +176,18 @@ const pageDescription = "Curated travel planning for trips worth taking. Certifi
           Reach out
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
         </button>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============================== NEWSLETTER ============================== -->
+  <section class="section section-soft">
+    <div class="container" style="text-align: center; max-width: 640px;">
+      <span class="eyebrow rise">Stay in the loop</span>
+      <h2 class="h2 rise" data-delay="1">Travel tips, Japan updates, and trip ideas.</h2>
+      <p class="lede rise" data-delay="2">No spam. Unsubscribe anytime. I only write when I have something worth sharing.</p>
+      <div class="rise" data-delay="3" style="margin-top: var(--space-8);">
+        <SubscriberForm tag="travel" />
       </div>
     </div>
   </section>


### PR DESCRIPTION
## What this does

Adds email subscription forms to the homepage and travel page, wired to the existing itsaydrian-subscriber Cloudflare Worker API.

### Features
- **Double opt-in:** New subscribers receive a verification email before being added to the list. Only confirmed subscribers receive future emails.
- **Tag segmentation:** Homepage subscribers are tagged general; travel page subscribers are tagged travel. Admin can send to either list or all.
- **Reusable component:** SubscriberForm.astro with email + name inputs, honeypot, loading/success/error states, and accessible status messaging.

### Changes
- **New component:** src/components/SubscriberForm.astro
- **Homepage:** New section above the contact band with a two-column layout (copy left, form right). Responsive stack at ≤800px.
- **Travel page:** New centered section below the CTA, tagged with travel.

### Backend changes (deployed)
- Added double opt-in flow to subscriber worker
- Added verified and verification_token columns to D1
- New /verify endpoint for email confirmation
- Welcome email only sent after verification
- Batch send only targets verified subscribers
- Existing 14 subscribers grandfathered as verified

### Preview
Check the Cloudflare Pages preview URL below once the build completes.

### Notes
- Uses existing design system CSS variables (no new styles added to global.css)
- Form is inline/embedded, not a floating widget
- Multiple forms on the same page get unique IDs via random UID generation