### PR TITLE
Move draft posts into src/posts with frontmatter

### DIFF
--- a/src/data/blog.ts
+++ b/src/data/blog.ts
@@ -20,6 +20,7 @@ export type BlogCategory =
   | "Travel"
   | "Japan"
   | "Apps"
+  | "Engineering"
   | "Pet care"
   | "Life in NYC";
 
@@ -27,6 +28,7 @@ export const categories: BlogCategory[] = [
   "Travel",
   "Japan",
   "Apps",
+  "Engineering",
   "Pet care",
   "Life in NYC",
 ];

--- a/src/posts/honcho-local-memory.mdx
+++ b/src/posts/honcho-local-memory.mdx
@@ -1,0 +1,156 @@
+---
+title: "Self-hosting Honcho for Hermes Agent memory"
+excerpt: "I run Honcho locally so my agent actually remembers who I am. Here's how the memory layer is wired into Hermes on a Raspberry Pi 5."
+date: "2026-06-14"
+category: "Engineering"
+slug: "honcho-local-memory"
+draft: true
+---
+
+Howdy. In my last post I wrote about running Hermes Agent on a Raspberry Pi 5 with [OpenCode Go](https://opencode.ai/go?ref=CE4TVB5MTZ) as the inference provider. This one is about the memory layer: I run [Honcho](https://honcho.dev/) locally so my agent actually remembers who I am.
+
+*(That's my OpenCode Go referral link — if you sign up through it, we both get a $5 usage credit.)*
+
+## Why local memory?
+
+A chatbot that forgets everything every session is fine for one-off questions. It's not fine for ongoing work. I wanted a user model that sticks around across days, projects, and devices — and I wanted it to live on hardware I control.
+
+Honcho does exactly that. It's an AI-native user-modeling layer. It observes conversations, builds a representation of the user, and injects relevant context back into the system prompt so the agent doesn't start from zero every time.
+
+## The setup
+
+I run Honcho self-hosted with Docker Compose on the same Raspberry Pi 5 that runs Hermes. The API is reachable at `http://localhost:8000`, and a quick health check confirms it's up:
+
+```bash
+curl http://localhost:8000/health
+# {"status":"ok"}
+```
+
+Hermes connects to it through the Honcho config at `~/.hermes/honcho.json`:
+
+```json
+{
+  "baseUrl": "http://localhost:8000",
+  "workspace": "hermes",
+  "aiPeer": "janine",
+  "recallMode": "hybrid",
+  "sessionStrategy": "per-directory"
+}
+```
+
+What each field does:
+
+- **baseUrl:** where my local Honcho API is listening.
+- **workspace:** `hermes` — the shared memory space across my Hermes profiles.
+- **aiPeer:** `janine` — the identity Hermes uses when it talks to me. Each profile can have its own peer.
+- **recallMode:** `hybrid` — Honcho injects base context automatically, and I can also call memory tools explicitly when I need something specific.
+- **sessionStrategy:** `per-directory` — each project directory gets its own Honcho session, so my travel-vault context doesn't leak into my app code.
+
+## How I wired it to Hermes
+
+The interactive wizard did most of the work:
+
+```bash
+hermes memory setup honcho
+```
+
+I chose "local," entered `http://localhost:8000`, and confirmed the workspace and peer names. Hermes created the Honcho host block and started routing memory calls there.
+
+You can verify it's working with:
+
+```bash
+hermes honcho status
+```
+
+That shows the resolved config, connection test, and peer info for the active profile.
+
+## What Honcho remembers
+
+Honcho maintains three things that get injected into the system prompt:
+
+1. **Session summary** — a digest of the current conversation so far.
+2. **User representation** — accumulated facts about me: preferences, habits, projects, communication style.
+3. **AI peer card** — a curated identity card for Janine, the AI peer.
+
+The order matters. The summary lands first so the model has immediate continuity, then the user representation, then the peer card.
+
+When I start a new session in a project directory, Honcho checks whether it already knows me. If it does, it uses a warm-start strategy and injects all three. If not, it falls back to a lighter cold-start prompt.
+
+## Observation and recall
+
+Honcho has two observation toggles per peer:
+
+- **observeMe** — whether the peer's own messages are observed.
+- **observeOthers** — whether the peer observes the other peer's messages.
+
+I leave all four on for full bidirectional observation. That means Janine learns from what I say *and* from what she says, and the user representation gets richer over time.
+
+Recall mode controls how the agent accesses memory:
+
+| Mode | Auto-inject context | Tools available |
+|------|---------------------|-----------------|
+| `hybrid` | Yes | Yes |
+| `context` | Yes | No |
+| `tools` | No | Yes |
+
+Hybrid is the default and the one I use. It gives the agent both automatic context and explicit memory tools without me having to micromanage which one to use.
+
+## Tools I can call
+
+When I need something specific from memory, there are five Honcho tools available:
+
+- **honcho_profile** — quick factual snapshot of a peer card.
+- **honcho_search** — semantic search over stored context, returns raw excerpts.
+- **honcho_context** — full snapshot: summary, representation, card, recent messages.
+- **honcho_reasoning** — synthesized answer from Honcho's dialectic engine.
+- **honcho_conclude** — write or delete a persistent fact.
+
+I use `honcho_profile` at the start of a session for a fast warmup, `honcho_search` when I need a specific past fact, and `honcho_conclude` when I share something I want remembered. I avoid `honcho_reasoning` on every turn because it costs more; auto-injection handles the routine stuff.
+
+## Session strategy
+
+The `per-directory` strategy means each folder I work in gets its own Honcho session. That's important because my travel advising context and my app development context have almost nothing to do with each other. I don't want hotel research bleeding into Cloudflare Worker configs.
+
+You can override it manually if needed:
+
+```bash
+hermes honcho map my-project-name
+```
+
+## What I use it for
+
+- **Project continuity.** I can stop working on Tiny Maintenance on Tuesday and pick it up on Thursday without re-explaining the codebase.
+- **Personal preferences.** It knows I prefer short sentences, that I avoid certain medication brand names in docs, and that I like evidence attached to claims.
+- **Workflow memory.** It remembers my canary-before-batch rule, my vault lint steps, and that I delegate code changes to Claude Code.
+- **Cross-channel consistency.** Whether I message from Discord or the terminal, the same memory layer is underneath.
+
+## Setup overview
+
+If you want to try local Honcho with Hermes:
+
+1. Clone the Honcho repo and start it locally:
+
+   ```bash
+   docker compose up -d
+   ```
+
+2. Verify the API: `curl http://localhost:8000/health`
+3. Run the Hermes setup wizard: `hermes memory setup honcho`
+4. Choose "local" and enter `http://localhost:8000`
+5. Confirm workspace and peer names, then check `hermes honcho status`
+
+From then on, Hermes will create Honcho sessions, observe messages, and inject context automatically.
+
+## What's still rough
+
+- Self-hosting means I'm my own ops team. Backups, updates, and the Postgres database are on me.
+- If the Pi is under heavy load, Honcho's dialectic calls can lag. I keep the reasoning level at `low` by default to keep things snappy.
+- Cold starts are thin. The first session in a new directory doesn't have much to inject until we've had a few exchanges.
+
+## Bottom line
+
+Local memory is the part of this stack that feels hardest to give up once you have it. The agent stops being a clever chatbot and starts being a persistent collaborator. Combined with Hermes and OpenCode Go, it's the closest thing I've found to an assistant that actually learns how I work.
+
+If you're curious about the inference side, I wrote about my Hermes + OpenCode Go setup [here](https://itsaydrian.com/blog/opencode-go-hermes/).
+
+Questions? Say howdy.

--- a/src/posts/opencode-go-hermes-honcho.mdx
+++ b/src/posts/opencode-go-hermes-honcho.mdx
@@ -1,0 +1,168 @@
+---
+title: "How I'm running Hermes Agent with OpenCode Go and local Honcho"
+excerpt: "The full stack: Hermes Agent on a Raspberry Pi 5, OpenCode Go for inference, and self-hosted Honcho for memory. One assistant, local data, every channel."
+date: "2026-06-14"
+category: "Engineering"
+slug: "opencode-go-hermes-honcho"
+draft: true
+---
+
+Howdy. I've been using the same setup long enough that it's stopped feeling like a toy and started feeling like infrastructure, so I figured I'd write it down before it changes again.
+
+The short version: I run [Hermes Agent](https://hermes-agent.nousresearch.com/docs/) on a Raspberry Pi 5, use [OpenCode Go](https://opencode.ai/go?ref=CE4TVB5MTZ) as the inference provider, and keep my memory layer local with a self-hosted [Honcho](https://honcho.dev/) instance. Everything talks to me through Discord, though the same agent also works from the terminal when I'm at my desk.
+
+*(That's my OpenCode Go referral link — if you sign up through it, we both get a $5 usage credit.)*
+
+## Why this stack?
+
+I wanted three things:
+
+1. **A model-agnostic agent.** I don't want to rewrite my workflow every time a new model drops.
+2. **Persistent memory that stays on my hardware.** Cloud memory is convenient, but I'm happier when my conversation history and user model live on a device I control.
+3. **One assistant across every channel.** If I'm on my laptop, I want a terminal. If I'm on my phone, I want Discord. Same agent, same context.
+
+Hermes does all of that. It's open-source, provider-agnostic, and has a gateway that can plug into Telegram, Discord, Slack, Signal, email, and a bunch of others.
+
+## The hardware
+
+Everything runs on a Raspberry Pi 5 under my desk.
+
+- **OS:** Linux 6.18.33+rpt-rpi-2712 (arm64)
+- **Memory:** 8 GB
+- **Storage:** SD card plus an external SSD for the heavier stuff
+
+It's not fast. But it's *mine*, it's quiet, and it sips power.
+
+## Models
+
+### Main model: `kimi-k2.7-code` via OpenCode Go
+
+My default model is `kimi-k2.7-code` from Moonshot AI, routed through OpenCode Go. That's the model doing the actual reasoning, tool-calling, and conversation in every session.
+
+```yaml
+model:
+  default: kimi-k2.7-code
+  provider: opencode-go
+```
+
+OpenCode Go is my provider because it gives me a clean API and good throughput without managing a dozen separate keys. I keep the API key in `~/.hermes/.env`; Hermes loads it from there.
+
+### Auxiliary models: `deepseek-v4-flash` via OpenCode Go
+
+Hermes offloads a bunch of background tasks to smaller auxiliary models. I've pointed most of those at `deepseek-v4-flash`, also through OpenCode Go. The config looks like this:
+
+```yaml
+auxiliary:
+  web_extract:
+    provider: opencode-go
+    model: deepseek-v4-flash
+  compression:
+    provider: opencode-go
+    model: deepseek-v4-flash
+  approval:
+    provider: opencode-go
+    model: deepseek-v4-flash
+  title_generation:
+    provider: opencode-go
+    model: deepseek-v4-flash
+  triage_specifier:
+    provider: opencode-go
+    model: deepseek-v4-flash
+  kanban_decomposer:
+    provider: opencode-go
+    model: deepseek-v4-flash
+  profile_describer:
+    provider: opencode-go
+    model: deepseek-v4-flash
+  curator:
+    provider: opencode-go
+    model: deepseek-v4-flash
+```
+
+What that actually means:
+
+- **Compression** summarizes the conversation when context gets long.
+- **Web extract** pulls the text out of URLs I throw at it.
+- **Approval** pre-checks shell commands before they run.
+- **Title generation** names my sessions so I can find them later.
+- **Triage / kanban / curator** handle task routing and skill maintenance.
+- **Profile describer** keeps my user model honest.
+
+A few auxiliaries are still on `auto` — vision, skills-hub search, MCP, and monitoring — which means Hermes picks the backend for those based on what's available.
+
+### Fallbacks and local options
+
+I also have providers configured for [OpenRouter](https://openrouter.ai/) and local [Ollama](https://ollama.com/), mostly so I can switch quickly if OpenCode Go is having a moment or I want to run something offline.
+
+```yaml
+providers:
+  openrouter:
+    api: https://openrouter.ai/api/v1
+    default_model: moonshotai/kimi-k2.6
+  ollama-launch:
+    api: http://127.0.0.1:11434/v1
+    default_model: qwen2.5:3b
+  local-ollama:
+    api: http://localhost:11434/v1
+    default_model: gemma3:4b
+```
+
+I don't use them as the default right now, but the option is there.
+
+## Memory: local Honcho
+
+The part I'm most attached to is memory.
+
+I run Honcho locally with Docker Compose at `http://localhost:8000`. Hermes connects to it through the `honcho.json` config:
+
+```json
+{
+  "baseUrl": "http://localhost:8000",
+  "workspace": "hermes",
+  "aiPeer": "janine",
+  "recallMode": "hybrid",
+  "sessionStrategy": "per-directory"
+}
+```
+
+- **Workspace:** `hermes` — one shared memory space across my profiles.
+- **AI peer:** `janine` — the identity Hermes uses when it talks to me.
+- **Recall mode:** `hybrid` — Honcho injects a base context block automatically, and I can also call memory tools explicitly when I need something specific.
+- **Sessions:** `per-directory` — each project gets its own Honcho session, so my travel-vault context doesn't leak into my app code.
+
+Honcho stores a user representation for me, a peer card for Janine, and a running session summary. That means when I pick up a project the next day, the agent already knows what we were doing, what I care about, and how I like things phrased.
+
+## What I actually use it for
+
+- **Coding:** Tiny Maintenance, Waymark, Cloudflare Workers, random scripts. Hermes reads the repo, runs tests, and delegates bigger refactors to Claude Code when needed.
+- **Travel admin:** I run a Fora travel advising practice, and Hermes helps me keep client research, standup notes, and evening wins in order.
+- **Content:** Drafting posts like this one, turning rough ideas into LinkedIn captions, and keeping a parking lot of ideas I don't have time for yet.
+- **System monitoring:** I check memory, disk, gateway status, and cron jobs without logging into a dashboard.
+
+## Setup overview
+
+If you want to try something similar, the rough steps are:
+
+1. Install Hermes Agent: `curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash`
+2. Set your provider/model: `hermes model` or edit `~/.hermes/config.yaml`.
+3. Add your OpenCode Go API key to `~/.hermes/.env`.
+4. Start Honcho locally: `docker compose up -d` in the Honcho repo, then `curl http://localhost:8000/health` to confirm.
+5. Wire Hermes to Honcho: `hermes memory setup honcho` → choose local → enter `http://localhost:8000`.
+6. Configure the gateway: `hermes gateway setup` and connect Discord (or whatever platform you want).
+7. Start the gateway: `hermes gateway run` or install it as a service.
+
+That's it. From then on, every message goes through your local agent, your local memory, and whichever model you pointed it at.
+
+## What's still rough
+
+- The Pi is fine for inference calls to OpenCode Go, but it's not running large local models itself. If I ever want to switch to local LLMs for real, I'll need beefier hardware.
+- `deepseek-v4-flash` is cheap and fast, but occasionally it's too literal for nuanced tasks. I tweak auxiliaries when I notice a pattern.
+- Honcho self-hosting means I'm my own ops team. Updates, backups, and the Postgres database are on me.
+
+## Bottom line
+
+This setup isn't the easiest path. A paid chatbot subscription would be faster to set up. But I like that I can swap models, keep my data local, and teach the agent my habits over time. It feels less like using a product and more like maintaining a workshop.
+
+If you're already running Hermes or curious about local memory, Honcho is worth the afternoon it takes to stand up. And OpenCode Go has been the least annoying inference provider I've tried in a while — which, honestly, is higher praise than it sounds.
+
+Questions? Say howdy.

--- a/src/posts/opencode-go-hermes.mdx
+++ b/src/posts/opencode-go-hermes.mdx
@@ -1,0 +1,153 @@
+---
+title: "Running Hermes Agent on a Raspberry Pi with OpenCode Go"
+excerpt: "I run Hermes Agent on a Raspberry Pi 5 and use OpenCode Go as my inference provider. Here's the model/provider half of the stack before it changes again."
+date: "2026-06-14"
+category: "Engineering"
+slug: "opencode-go-hermes"
+draft: true
+---
+
+Howdy. I've been running my own AI agent setup long enough that it feels less like a toy and more like infrastructure, so I figured I'd write down the model/provider half before it changes again.
+
+The short version: I run [Hermes Agent](https://hermes-agent.nousresearch.com/docs/) on a Raspberry Pi 5, and I use [OpenCode Go](https://opencode.ai/go?ref=CE4TVB5MTZ) as my inference provider.
+
+*(That's my OpenCode Go referral link — if you sign up through it, we both get a $5 usage credit.)*
+
+## Why Hermes?
+
+Hermes is an open-source agent framework from Nous Research. It can talk to basically any LLM provider, runs in your terminal, and has a gateway that plugs into Discord, Telegram, Slack, Signal, email, and more.
+
+I wanted three things:
+
+1. **Model flexibility.** I don't want to rebuild my workflow every time a better model ships.
+2. **Tool use on my own hardware.** Hermes can read files, run shell commands, search the web, and delegate to other agents.
+3. **One assistant everywhere.** Terminal when I'm at my desk, Discord when I'm on my phone.
+
+Hermes checks all three.
+
+## The hardware
+
+Everything lives on a Raspberry Pi 5 under my desk.
+
+- **OS:** Linux 6.18.33+rpt-rpi-2712 (arm64)
+- **Memory:** 8 GB
+- **Storage:** SD card plus an external SSD for the heavier stuff
+
+It's not fast, but it's quiet, it's mine, and it sips power. The actual inference happens remotely through OpenCode Go, so the Pi only has to manage the agent loop, tool calls, and gateway.
+
+## Main model: `kimi-k2.7-code` via OpenCode Go
+
+My default model is `kimi-k2.7-code` from Moonshot AI, routed through OpenCode Go. That's the model doing the reasoning, tool selection, and conversation.
+
+```yaml
+model:
+  default: kimi-k2.7-code
+  provider: opencode-go
+```
+
+I keep the OpenCode Go API key in `~/.hermes/.env`, and Hermes loads it from there. The provider is configured like this:
+
+```yaml
+providers:
+  opencode-go:
+    name: OpenCode Go
+```
+
+OpenCode Go has been the cleanest provider I've tried in a while. One key, good throughput, and I can point it at whatever model I want without juggling a dozen endpoints.
+
+## Auxiliary models: `deepseek-v4-flash` via OpenCode Go
+
+Hermes offloads a bunch of background work to auxiliary models. I've pointed most of those at `deepseek-v4-flash`, also through OpenCode Go, because it's cheap and fast enough for tasks that don't need the main model's depth.
+
+My current config:
+
+```yaml
+auxiliary:
+  compression:
+    provider: opencode-go
+    model: deepseek-v4-flash
+  web_extract:
+    provider: opencode-go
+    model: deepseek-v4-flash
+  approval:
+    provider: opencode-go
+    model: deepseek-v4-flash
+  title_generation:
+    provider: opencode-go
+    model: deepseek-v4-flash
+  triage_specifier:
+    provider: opencode-go
+    model: deepseek-v4-flash
+  kanban_decomposer:
+    provider: opencode-go
+    model: deepseek-v4-flash
+  profile_describer:
+    provider: opencode-go
+    model: deepseek-v4-flash
+  curator:
+    provider: opencode-go
+    model: deepseek-v4-flash
+```
+
+What each one actually does:
+
+- **Compression** summarizes the conversation when context gets long.
+- **Web extract** pulls the text out of URLs I throw at it.
+- **Approval** pre-checks shell commands before they run.
+- **Title generation** names my sessions so I can find them later.
+- **Triage / kanban / curator** route tasks and maintain my skills library.
+- **Profile describer** keeps my user model from drifting into fiction.
+
+A few auxiliaries are still on `auto` — vision, skills-hub search, MCP, and monitoring — which means Hermes picks the backend for those based on what's available.
+
+## Fallbacks and local options
+
+I also have OpenRouter and local Ollama configured, mostly so I can switch quickly if OpenCode Go is having a moment or I want to run something offline.
+
+```yaml
+providers:
+  openrouter:
+    api: https://openrouter.ai/api/v1
+    default_model: moonshotai/kimi-k2.6
+  ollama-launch:
+    api: http://127.0.0.1:11434/v1
+    default_model: qwen2.5:3b
+  local-ollama:
+    api: http://localhost:11434/v1
+    default_model: gemma3:4b
+```
+
+I don't use them as the default right now, but the option is there.
+
+## What I use it for
+
+- **Coding:** Tiny Maintenance, Waymark, Cloudflare Workers, random scripts. Hermes reads the repo, runs tests, and delegates bigger refactors to Claude Code when needed.
+- **Travel admin:** I run a Fora travel advising practice, and Hermes helps with client research, standup notes, and end-of-day wins.
+- **Content:** Drafting posts, turning rough ideas into LinkedIn captions, and keeping a parking lot of ideas I don't have time for yet.
+- **System monitoring:** Checking memory, disk, gateway status, and cron jobs without logging into a dashboard.
+
+## Setup overview
+
+If you want to try the same provider/model stack:
+
+1. Install Hermes Agent: `curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash`
+2. Set the model/provider: `hermes model` or edit `~/.hermes/config.yaml`.
+3. Add your OpenCode Go API key to `~/.hermes/.env`.
+4. Configure the gateway if you want Discord/Slack/etc.: `hermes gateway setup`
+5. Start the gateway: `hermes gateway run` or install it as a service.
+
+That's the core loop. Everything else — memory, extra tools, custom skills — layers on top.
+
+## What's still rough
+
+- `deepseek-v4-flash` is fast, but occasionally too literal for nuanced tasks. I tweak auxiliaries when I notice a pattern.
+- The Pi handles the agent loop fine, but it's not running large local LLMs. If I ever want to go fully local, I'll need beefier hardware.
+- Hermes has a lot of knobs. It took a few sessions to figure out which auxiliary settings actually mattered for my workflow.
+
+## Bottom line
+
+This setup isn't the easiest path. A paid chatbot subscription would be faster to set up. But I like that I can swap models, keep the agent running on my own hardware, and teach it my habits over time. It feels less like using a product and more like maintaining a workshop.
+
+If you want to try OpenCode Go with Hermes, [here's that referral link again](https://opencode.ai/go?ref=CE4TVB5MTZ) — we both get $5 in usage credits.
+
+Questions? Say howdy.


### PR DESCRIPTION
Moves the three draft posts from docs/ into src/posts/ as MDX with frontmatter, marks them as drafts, and adds Engineering to the blog category list.