### PR TITLE
fix(layout): read GA4 ID inline from import.meta.env

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -23,8 +23,6 @@ const {
   preloadImage
 } = Astro.props;
 
-const gaMeasurementId = import.meta.env.PUBLIC_GA_MEASUREMENT_ID;
-
 import '../styles/global.css';
 ---
 
@@ -69,10 +67,10 @@ import '../styles/global.css';
   <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Inter:wght@400;500;600;700&family=Noto+Sans+JP:wght@300;400;500&display=swap" rel="stylesheet">
 
   <slot name="head" />
-  {gaMeasurementId && (
+  {import.meta.env.PUBLIC_GA_MEASUREMENT_ID && (
     <>
-      <script is:inline async src={`https://www.googletagmanager.com/gtag/js?id=${gaMeasurementId}`}></script>
-      <script is:inline set:html={`window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','${gaMeasurementId}');`}></script>
+      <script is:inline async src={`https://www.googletagmanager.com/gtag/js?id=${import.meta.env.PUBLIC_GA_MEASUREMENT_ID}`}></script>
+      <script is:inline set:html={`window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','${import.meta.env.PUBLIC_GA_MEASUREMENT_ID}');`}></script>
     </>
   )}
   <script is:inline>


### PR DESCRIPTION
The frontmatter const was not picking up the GitHub Actions var during prerender. Reading `import.meta.env.PUBLIC_GA_MEASUREMENT_ID` directly in the template makes the gtag render correctly when the var is set, and omit it when it is not.