### PR TITLE
fix(structured-data): add required address and aggregateRating fields

### DIFF
--- a/src/pages/apps/tiny-maintenance/index.astro
+++ b/src/pages/apps/tiny-maintenance/index.astro
@@ -4,7 +4,7 @@ import Layout from '../../../layouts/Layout.astro';
 const pageTitle = "Tiny Maintenance — iOS";
 const pageDescription = "Track recurring upkeep for your home, car, garden, and pets. Reminders, templates, and a one-tap done — offline, no account required.";
 ---
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Tiny Maintenance","applicationCategory":"LifestyleApplication","operatingSystem":"iOS","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"},"inAppPurchase":"Pro subscription","description":"Track recurring upkeep with reminders, templates, and one-tap done","url":"https://itsaydrian.com/apps/tiny-maintenance","downloadUrl":"https://apps.apple.com/app/tiny-maintenance-reminders/id6760630113","author":{"@type":"Person","name":"Aydrian Howard"},"publisher":{"@type":"Organization","name":"ItsAydrian LLC"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Tiny Maintenance","applicationCategory":"LifestyleApplication","operatingSystem":"iOS","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"},"aggregateRating":{"@type":"AggregateRating","ratingValue":"5","ratingCount":"1"},"description":"Track recurring upkeep with reminders, templates, and one-tap done","url":"https://itsaydrian.com/apps/tiny-maintenance","downloadUrl":"https://apps.apple.com/app/tiny-maintenance-reminders/id6760630113","author":{"@type":"Person","name":"Aydrian Howard"},"publisher":{"@type":"Organization","name":"ItsAydrian LLC"}}</script>
 
 <Layout
   title="Tiny Maintenance"

--- a/src/pages/pet-care/index.astro
+++ b/src/pages/pet-care/index.astro
@@ -14,7 +14,7 @@ const pageDescription = "Kind, careful dog walking, sitting, and overnight care 
   overlayHeader={true}
   preloadImage="/assets/atticus-hero.jpg"
 >
-  <script slot="head" type="application/ld+json" is:raw>{"@context":"https://schema.org","@type":"LocalBusiness","name":"ItsAydrian Pet Care","url":"https://itsaydrian.com/pet-care","email":"howdy@itsaydrian.com","areaServed":"Manhattan, New York, NY","knowsAbout":["Dog walking","Pet sitting","Overnight pet care"],"sameAs":["https://www.rover.com/sit/aydrih08941"]}</script>
+  <script slot="head" type="application/ld+json" is:raw>{"@context":"https://schema.org","@type":"LocalBusiness","name":"ItsAydrian Pet Care","url":"https://itsaydrian.com/pet-care","email":"howdy@itsaydrian.com","address":{"@type":"PostalAddress","addressLocality":"New York","addressRegion":"NY","addressCountry":"US"},"areaServed":"Manhattan, New York, NY","knowsAbout":["Dog walking","Pet sitting","Overnight pet care"],"sameAs":["https://www.rover.com/sit/aydrih08941"]}</script>
 
   <!-- ============================== HERO ============================== -->
   <section class="hero" aria-labelledby="pet-hero-title">

--- a/src/pages/travel/index.astro
+++ b/src/pages/travel/index.astro
@@ -17,7 +17,7 @@ const pageDescription = "Curated travel planning for trips worth taking. Certifi
   overlayHeader={true}
   preloadImage="/assets/aydrian-travel-800.jpg"
 >
-  <script slot="head" type="application/ld+json" is:raw>{"@context":"https://schema.org","@type":"TravelAgency","name":"ItsAydrian Travel","url":"https://itsaydrian.com/travel","email":"aydrian.howard@foratravel.com","founder":{"@type":"Person","name":"Aydrian Howard"},"areaServed":"Worldwide","knowsAbout":["Japan travel","Luxury travel","Itinerary planning","Hotel sourcing","Restaurant reservations"],"memberOf":{"@type":"Organization","name":"Fora Travel"},"sameAs":["https://www.foratravel.com/advisor/aydrian-howard"]}</script>
+  <script slot="head" type="application/ld+json" is:raw>{"@context":"https://schema.org","@type":"TravelAgency","name":"ItsAydrian Travel","url":"https://itsaydrian.com/travel","email":"aydrian.howard@foratravel.com","address":{"@type":"PostalAddress","addressLocality":"New York","addressRegion":"NY","addressCountry":"US"},"founder":{"@type":"Person","name":"Aydrian Howard"},"areaServed":"Worldwide","knowsAbout":["Japan travel","Luxury travel","Itinerary planning","Hotel sourcing","Restaurant reservations"],"memberOf":{"@type":"Organization","name":"Fora Travel"},"sameAs":["https://www.foratravel.com/advisor/aydrian-howard"]}</script>
 
   <!-- ============================== HERO ============================== -->
   <section class="hero" aria-labelledby="travel-hero-title">


### PR DESCRIPTION
Fixes SEMrush structured-data errors reported on 17 Jun 2026.

Changes:
- `/apps/tiny-maintenance/`: removed unrecognized `inAppPurchase` property; added `aggregateRating` from App Store data (5.0, 1 rating).
- `/pet-care/`: added `address` (`PostalAddress`) to `LocalBusiness` schema.
- `/travel/`: added `address` (`PostalAddress`) to `TravelAgency` schema.

Closes #52 (partial — remaining audit/keyword tasks still tracked there).